### PR TITLE
Coruro may be extended with custom adapters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 before_install:
   - gem install bundler -v 1.16.1
   - gem install mailcatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - gem install mailcatcher
 
 install:
-  - cd coruro-ruby && bundle install --path vendor/bundle
+  - (cd coruro-ruby && bundle install --path vendor/bundle)
 
-script: cd coruro-ruby && bin/rake
+script: (cd coruro-ruby && bin/rake)
 

--- a/coruro-ruby/Gemfile.lock
+++ b/coruro-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coruro-ruby (0.4.0)
+    coruro-ruby (0.5.0)
       mail (~> 2.7.0)
 
 GEM

--- a/coruro-ruby/features/custom_adapters.feature
+++ b/coruro-ruby/features/custom_adapters.feature
@@ -1,0 +1,17 @@
+Feature: Custom adapters
+  In order to be able to leverage adapters the Coruro team hasn't considered
+  As a developer
+  I would like Coruro to let me define custom adapters
+
+
+  Scenario: Starting a custom adapter
+    Given the custom adapter is not already running
+    When I instantiate Coruro with the custom adapter
+    Then Coruro knows the custom adapter is up
+
+
+  Scenario: Ending a custom adapter
+    Given Coruro has started the custom adapter
+    When I stop Coruro with the custom adapter
+    Then Coruro knows the custom adapter is not up
+

--- a/coruro-ruby/features/mailcatcher_integration.feature
+++ b/coruro-ruby/features/mailcatcher_integration.feature
@@ -1,9 +1,9 @@
 Feature: Mailcatcher integration
-  In order for life to be easy and wonderful
+  In order to not have to manage processes in my feature test suite
   As a developer
-  I would like coruro to manage the Mailcatcher process for me
+  I would like Coruro to manage the Mailcatcher process for me
 
   Scenario: Lazily starting coruro
-    Given mailcatcher is not already running
+    Given the mailcatcher adapter is not already running
     When I instantiate Coruro with the mailcatcher adapter
-    Then Coruro knows mailcatcher is up
+    Then Coruro knows the mailcatcher adapter is up

--- a/coruro-ruby/features/step_definitions/steps.rb
+++ b/coruro-ruby/features/step_definitions/steps.rb
@@ -1,13 +1,26 @@
-Given("mailcatcher is not already running") do
-  Coruro.new(adapter: :mailcatcher).stop
+Given(/Coruro has started the (.*) adapter/) do |adapter|
+  @coruro = Coruro.new(adapter: adapter.to_sym,
+                       adapter_config: { expose_streams: { stdout: $stdout, stderr: $stderr } })
 end
 
-When("I instantiate Coruro with the mailcatcher adapter") do
-  Coruro.new(adapter: :mailcatcher,
-             adapter_config: { expose_streams: { stdout: $stdout, stderr: $stderr } })
+Given(/the (.*) adapter is not already running/) do |adapter|
+ Coruro.new(adapter: adapter.to_sym).stop
+end
+
+When(/I instantiate Coruro with the (.*) adapter/) do |adapter|
+  @coruro = Coruro.new(adapter: adapter.to_sym,
+                       adapter_config: { expose_streams: { stdout: $stdout, stderr: $stderr } })
+end
+
+When(/I stop Coruro with the (.*) adapter/) do |adapter|
+  @coruro.stop
 end
 
 
-Then("Coruro knows mailcatcher is up") do
-  Coruro.new(adapter: :mailcatcher).adapter.up?
+Then(/Coruro knows the (.*) adapter is up/) do |adapter|
+  assert @coruro.adapter.up?
+end
+
+Then(/Coruro knows the (.*) adapter is not up/) do |adapter|
+  assert !@coruro.adapter.up?
 end

--- a/coruro-ruby/features/support/env.rb
+++ b/coruro-ruby/features/support/env.rb
@@ -1,5 +1,64 @@
 require 'coruro'
 
+require 'minitest/spec'
+
+class MinitestWorld
+  include Minitest::Assertions
+  attr_accessor :assertions
+
+  def initialize
+    self.assertions = 0
+  end
+end
+
+World do
+  MinitestWorld.new
+end
+
+class CustomAdapter
+  attr_accessor :config
+  def initialize(config:, timeout:)
+  end
+
+  def up?
+    runner.up?(config)
+  end
+
+  def start
+    runner.start(config)
+  end
+
+  def stop
+    runner.stop
+  end
+
+  def runner
+    @_runner ||= Runner.instance
+  end
+
+  class Runner
+    include Singleton
+    attr_accessor :up
+
+
+    def start(config)
+      self.up = true
+    end
+
+    def up?(config)
+      !!up
+    end
+
+    def stop
+      self.up = false;
+    end
+  end
+end
+
+Coruro.adapters[:custom] = CustomAdapter;
+
 at_exit do
-  Coruro.new(adapter: :mailcatcher).stop
+  [:mailcatcher, :custom].each do |adapter|
+    Coruro.new(adapter: adapter).stop
+  end
 end

--- a/coruro-ruby/lib/coruro.rb
+++ b/coruro-ruby/lib/coruro.rb
@@ -12,9 +12,8 @@ class Coruro
   def_delegators :adapter, :all, :where, :stop
 
   def initialize(adapter:, on_wait_tick: -> (count) { }, timeout: 1.0, adapter_config: {})
-    case adapter
-    when :mailcatcher
-      self.adapter = MailcatcherAdapter.new(timeout: timeout, config: adapter_config)
+    if adapters.key?(adapter)
+      self.adapter = adapters[adapter].new(timeout: timeout, config: adapter_config)
       self.adapter.start unless self.adapter.up?
     else
       raise UnrecognizedAdapterError, adapter
@@ -33,5 +32,14 @@ class Coruro
   end
 
   class UnrecognizedAdapterError < StandardError; end
+
+
+  def adapters
+    self.class.adapters
+  end
+
+  def self.adapters
+    @adapters ||= { mailcatcher: MailcatcherAdapter }
+  end
 end
 

--- a/coruro-ruby/lib/coruro/mailcatcher_adapter.rb
+++ b/coruro-ruby/lib/coruro/mailcatcher_adapter.rb
@@ -5,27 +5,9 @@ require 'singleton'
 require_relative 'unbundle'
 
 class Coruro
-  class Configuration
-    attr_accessor :config
-    def initialize(config)
-      self.config = config
-    end
-
-    def http_root
-      config.fetch(:http_root, 'http://localhost:1080')
-    end
-
-    def expose_stream?(stream)
-      !expose_streams[stream].nil?
-    end
-
-    def expose_streams
-      config.fetch(:expose_streams, {})
-    end
-  end
-
   # Translates between Curoro and Mailcatcher's API
   class MailcatcherAdapter
+
     attr_accessor :runner, :timeout, :config
     extend Forwardable
     def_delegators :runner, :stop
@@ -57,7 +39,6 @@ class Coruro
       return value.any? { |child| match?(query, child) } if value.respond_to?(:any?)
       raise ArgumentError, "Query #{query} must respond to `match?` or Value #{value} must respond to `any?`"
     end
-
 
     def up?
       runner.up?(config)
@@ -133,6 +114,25 @@ class Coruro
 
       private def streams
         { stderr: stderr, stdout: stdout, stdin: stdin }
+      end
+    end
+
+    class Configuration
+      attr_accessor :config
+      def initialize(config)
+        self.config = config
+      end
+
+      def http_root
+        config.fetch(:http_root, 'http://localhost:1080')
+      end
+
+      def expose_stream?(stream)
+        !expose_streams[stream].nil?
+      end
+
+      def expose_streams
+        config.fetch(:expose_streams, {})
       end
     end
   end

--- a/coruro-ruby/lib/coruro/mailcatcher_adapter.rb
+++ b/coruro-ruby/lib/coruro/mailcatcher_adapter.rb
@@ -35,8 +35,9 @@ class Coruro
 
     def match?(query, value)
       return false if query.nil?
-      return query.match?(value) if query.respond_to?(:match?) && !value.respond_to?(:any?)
       return value.any? { |child| match?(query, child) } if value.respond_to?(:any?)
+      return query.match?(value) if query.respond_to?(:match?)
+      return !query.match(value).nil? if query.respond_to?(:match)
       raise ArgumentError, "Query #{query} must respond to `match?` or Value #{value} must respond to `any?`"
     end
 


### PR DESCRIPTION
The ability to add adapters for services we haven't considered yet will make Coruro a bit more flexible. For instance, a coruro-oauth2-adapter could be useful for someone trying to test a service that interacts with an oauth2 provider, or a coruro-stripe-adapter for someone who wants to feature test against stripe.
