### PR TITLE
Don't start mailcatcher when working with a remote server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ rvm:
 before_install:
   - gem install bundler -v 1.16.1
   - gem install mailcatcher
+env:
+  # This doesn't matter just yet, so long as there's a server
+  # listening for http requests
+  MAILCATCHER_ADAPTER_REMOTE_HOST: "https://www.zinc.coop/"
 
 install:
   - (cd coruro-ruby && bundle install --path vendor/bundle)

--- a/coruro-ruby/.env.example
+++ b/coruro-ruby/.env.example
@@ -1,0 +1,2 @@
+# Replace this with the location for
+MAILCATCHER_ADAPTER_REMOTE_HOST="https://www.zinc.coop/"

--- a/coruro-ruby/.gitignore
+++ b/coruro-ruby/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.env

--- a/coruro-ruby/Gemfile.lock
+++ b/coruro-ruby/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
+    dotenv (2.7.5)
+    ffi (1.13.1)
     gherkin (5.0.0)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
@@ -39,6 +41,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (13.0.1)
+    sys-proctable (1.2.5)
+      ffi
 
 PLATFORMS
   ruby
@@ -47,9 +51,11 @@ DEPENDENCIES
   bundler (~> 1.16)
   coruro-ruby!
   cucumber (~> 3)
+  dotenv
   minitest (~> 5.0)
   pry
   rake (~> 13.0)
+  sys-proctable
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/coruro-ruby/coruro-ruby.gemspec
+++ b/coruro-ruby/coruro-ruby.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "dotenv"
+  spec.add_development_dependency "sys-proctable"
 end

--- a/coruro-ruby/features/mailcatcher_integration.feature
+++ b/coruro-ruby/features/mailcatcher_integration.feature
@@ -3,7 +3,13 @@ Feature: Mailcatcher integration
   As a developer
   I would like Coruro to manage the Mailcatcher process for me
 
-  Scenario: Lazily starting coruro
+  Scenario: Starting mailcatcher if it is not running already
     Given the mailcatcher adapter is not already running
     When I instantiate Coruro with the mailcatcher adapter
     Then Coruro knows the mailcatcher adapter is up
+
+  Scenario: Bypass starting mailcatcher when it is already running
+    Given the mailcatcher adapter is not already running
+    When the mailcatcher adapter is configured for a remote server
+    Then Coruro knows the mailcatcher adapter is up
+    And Coruro did not start a mailcatcher process

--- a/coruro-ruby/features/step_definitions/steps.rb
+++ b/coruro-ruby/features/step_definitions/steps.rb
@@ -4,8 +4,18 @@ Given(/Coruro has started the (.*) adapter/) do |adapter|
 end
 
 Given(/the (.*) adapter is not already running/) do |adapter|
- Coruro.new(adapter: adapter.to_sym).stop
+  Coruro.new(adapter: adapter.to_sym).stop
 end
+
+CONFIGURATIONS = {
+  "a remote server": {
+    http_root: ENV['MAILCATCHER_ADAPTER_REMOTE_HOST']
+  }
+}
+
+When(/the (.*) adapter is configured for (.*)/) do |adapter, configuration|
+  @coruro ||= Coruro.new(adapter: adapter.to_sym, adapter_config: CONFIGURATIONS[configuration.to_sym])
+ end
 
 When(/I instantiate Coruro with the (.*) adapter/) do |adapter|
   @coruro = Coruro.new(adapter: adapter.to_sym,
@@ -16,11 +26,16 @@ When(/I stop Coruro with the (.*) adapter/) do |adapter|
   @coruro.stop
 end
 
-
 Then(/Coruro knows the (.*) adapter is up/) do |adapter|
   assert @coruro.adapter.up?
 end
 
 Then(/Coruro knows the (.*) adapter is not up/) do |adapter|
   assert !@coruro.adapter.up?
+end
+
+
+Then("Coruro did not start a mailcatcher process") do
+  mailcatcher_processes = Sys::ProcTable.ps.select { |x| x.cmdline.include?("mailcatcher") }
+  assert mailcatcher_processes.empty?
 end

--- a/coruro-ruby/features/support/env.rb
+++ b/coruro-ruby/features/support/env.rb
@@ -1,6 +1,13 @@
+require 'dotenv/load'
+
 require 'coruro'
 
 require 'minitest/spec'
+require 'sys/proctable'
+require 'pry'
+
+Dotenv.load
+
 
 class MinitestWorld
   include Minitest::Assertions


### PR DESCRIPTION
Sometimes we want to use Coruro to check a mailcatcher instance being
ran in docker or an internal network.

However, I was having issues figuring out how to not startup the
local mailcatcher.

So I put a feature example together to isolate the configuration.