### PR TITLE
Run CI against the latest 2.3~2.7 ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 before_install:
   - gem install bundler -v 1.16.1
   - gem install mailcatcher


### PR DESCRIPTION
I'll merge this in a couple weeks if no one objects; but I noticed we were falling behind on keeping this gem's CI suite running against the latest released versions of Ruby.